### PR TITLE
Configure travis.ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: ruby
+rvm:
+  - 2.2
+  - 2.5
+  - jruby-1.7.27
+script:
+  - bundle exec rubocop

--- a/Gemfile
+++ b/Gemfile
@@ -7,3 +7,4 @@ git_source(:github) { 'https://github.com/hawkins/lard' }
 gem 'httparty', '~> 0.16.2'
 gem 'paint', '~> 2.0'
 gem 'thor', '~> 0.20.0'
+gem 'rubocop', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -6,5 +6,5 @@ git_source(:github) { 'https://github.com/hawkins/lard' }
 
 gem 'httparty', '~> 0.16.2'
 gem 'paint', '~> 2.0'
-gem 'thor', '~> 0.20.0'
 gem 'rubocop', require: false
+gem 'thor', '~> 0.20.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,28 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    ast (2.4.0)
     httparty (0.16.2)
       multi_xml (>= 0.5.2)
+    jaro_winkler (1.5.1)
     multi_xml (0.6.0)
     paint (2.0.1)
+    parallel (1.12.1)
+    parser (2.5.1.2)
+      ast (~> 2.4.0)
+    powerpack (0.1.2)
+    rainbow (3.0.0)
+    rubocop (0.59.2)
+      jaro_winkler (~> 1.5.1)
+      parallel (~> 1.10)
+      parser (>= 2.5, != 2.5.1.1)
+      powerpack (~> 0.1)
+      rainbow (>= 2.2.2, < 4.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-progressbar (1.10.0)
     thor (0.20.0)
+    unicode-display_width (1.4.0)
 
 PLATFORMS
   ruby
@@ -13,6 +30,7 @@ PLATFORMS
 DEPENDENCIES
   httparty (~> 0.16.2)
   paint (~> 2.0)
+  rubocop
   thor (~> 0.20.0)
 
 BUNDLED WITH


### PR DESCRIPTION
Pretty much does nothing yet - but will handle tests and make sure PR's don't break rubocop:)

- [x] Rubocop
- ~~[ ] Tests~~
- Ruby versions:
  - 2.2
  - 2.5
  - jruby 1.7.27

The ruby versions are kind of random. They're the ones I care the most about, but I'm not sure which else we should monitor. I'll check back on that in the future.